### PR TITLE
Update to Rosetta 1.1

### DIFF
--- a/src/JavaCatalog.ts
+++ b/src/JavaCatalog.ts
@@ -16,7 +16,9 @@ export class JavaCatalog {
         const list = root.getElementsByTagName('a');
         for (const item of list) {
             const href = item.attributes['href'];
-            if (!href.startsWith('zombie/')) continue;
+            if (href == undefined || !href.endsWith(".html")) continue;
+            const title = item.attributes['title']
+            if (title == undefined || !title.startsWith("class in")) continue;
             classList.push(href);
         }
 

--- a/src/JavaCatalog.ts
+++ b/src/JavaCatalog.ts
@@ -18,7 +18,7 @@ export class JavaCatalog {
             const href = item.attributes['href'];
             if (href == undefined || !href.endsWith(".html")) continue;
             const title = item.attributes['title']
-            if (title == undefined || !title.startsWith("class in")) continue;
+            if (title == undefined || !(title.includes("interface in ") || title.includes("class in "))) continue;
             classList.push(href);
         }
 

--- a/src/JavaCatalog.ts
+++ b/src/JavaCatalog.ts
@@ -33,7 +33,7 @@ export class JavaCatalog {
                 }
                 this.packages[name].addClass(clazz);
                 for (var nestedClass of clazz.nestedClasses) {
-                    nestedClass = name.replaceAll(".", "/") + "/" + nestedClass + ".html"
+                    nestedClass = classURI.substring(0, classURI.lastIndexOf("/") + 1) + nestedClass + ".html"
                     if (!classList.includes(nestedClass)) {
                         classList.push(nestedClass)
                     }

--- a/src/JavaCatalog.ts
+++ b/src/JavaCatalog.ts
@@ -3,10 +3,10 @@
 import * as fs from 'fs';
 import { parse } from 'node-html-parser';
 import { JavaClass } from './JavaClass';
-import { JavaNamespace } from './JavaNamespace';
+import { JavaPackage } from './JavaPackage';
 
 export class JavaCatalog {
-    readonly namespaces: { [name: string]: JavaNamespace } = {};
+    readonly packages: { [name: string]: JavaPackage } = {};
 
     parse(path: string) {
         const html = fs.readFileSync(path).toString();
@@ -25,11 +25,11 @@ export class JavaCatalog {
             const uri = `./docs/${classURI}`;
             try {
                 const clazz = new JavaClass(uri);
-                const name = clazz.namespace;
-                if (!this.namespaces[name]) {
-                    this.namespaces[name] = new JavaNamespace(name);
+                const name = clazz.package;
+                if (!this.packages[name]) {
+                    this.packages[name] = new JavaPackage(name);
                 }
-                this.namespaces[name].addClass(clazz);
+                this.packages[name].addClass(clazz);
                 for (var nestedClass of clazz.nestedClasses) {
                     nestedClass = name.replaceAll(".", "/") + "/" + nestedClass + ".html"
                     if (!classList.includes(nestedClass)) {
@@ -50,10 +50,10 @@ export class JavaCatalog {
     }
 
     save(format: 'yml' | 'json') {
-        const keys = Object.keys(this.namespaces);
+        const keys = Object.keys(this.packages);
         keys.sort((a, b) => a.localeCompare(b));
         for (const key of keys) {
-            this.namespaces[key].save(format);
+            this.packages[key].save(format);
         }
     }
 }

--- a/src/JavaCatalog.ts
+++ b/src/JavaCatalog.ts
@@ -16,7 +16,7 @@ export class JavaCatalog {
         const list = root.getElementsByTagName('a');
         for (const item of list) {
             const href = item.attributes['href'];
-            if (href == undefined || !href.endsWith(".html")) continue;
+            if (href == undefined || !href.endsWith(".html") || href.startsWith("https://")) continue;
             const title = item.attributes['title']
             if (title == undefined || !(title.includes("interface in ") || title.includes("class in "))) continue;
             classList.push(href);
@@ -33,10 +33,6 @@ export class JavaCatalog {
                 }
                 this.packages[name].addClass(clazz);
                 for (var nestedClass of clazz.nestedClasses) {
-                    // TODO: fix these getting in here in the first place
-                    if (nestedClass.startsWith("https://")) {
-                        continue;
-                    }
                     nestedClass = classURI.substring(0, classURI.lastIndexOf("/") + 1) + nestedClass + ".html"
                     if (!classList.includes(nestedClass)) {
                         classList.push(nestedClass)

--- a/src/JavaCatalog.ts
+++ b/src/JavaCatalog.ts
@@ -18,7 +18,7 @@ export class JavaCatalog {
             const href = item.attributes['href'];
             if (href == undefined || !href.endsWith(".html")) continue;
             const title = item.attributes['title']
-            if (title == undefined || !(title.includes("interface in ") || title.includes("class in "))) continue;
+            if (title == undefined || !title.startsWith("class in")) continue;
             classList.push(href);
         }
 
@@ -33,6 +33,10 @@ export class JavaCatalog {
                 }
                 this.packages[name].addClass(clazz);
                 for (var nestedClass of clazz.nestedClasses) {
+                    // TODO: fix these getting in here in the first place
+                    if (nestedClass.startsWith("https://")) {
+                        continue;
+                    }
                     nestedClass = classURI.substring(0, classURI.lastIndexOf("/") + 1) + nestedClass + ".html"
                     if (!classList.includes(nestedClass)) {
                         classList.push(nestedClass)

--- a/src/JavaClass.ts
+++ b/src/JavaClass.ts
@@ -28,7 +28,7 @@ export class JavaClass extends JavaElement {
         const { element } = this;
 
         // Java Package
-        this.package = this.getText('.header > .sub-title > a')!;
+        this.package = this.getElement('.header > .sub-title > .package-label-in-type')?.parentNode.parentNode.lastChild.text!;
 
         // Java Type & Modifiers
         const split = this.getText('.type-signature > .modifiers')!.split(' ');

--- a/src/JavaClass.ts
+++ b/src/JavaClass.ts
@@ -53,7 +53,7 @@ export class JavaClass extends JavaElement {
         }
         this.name = name;
 
-        const notes = this.getText('.class-description .block');
+        const notes = this.getElement('.class-description .block')?.parentNode.innerText;
         if (notes != undefined) {
             this.notes = removeHtmlEncoding(notes.trim());
         }

--- a/src/JavaClass.ts
+++ b/src/JavaClass.ts
@@ -14,7 +14,7 @@ export class JavaClass extends JavaElement {
     readonly methods: { [name: string]: JavaMethod[] } = {};
     readonly constructors: JavaConstructor[] = [];
 
-    readonly namespace: string;
+    readonly package: string;
     readonly name: string;
     readonly modifiers: string[] = [];
     readonly notes: string | undefined;
@@ -28,7 +28,7 @@ export class JavaClass extends JavaElement {
         const { element } = this;
 
         // Java Package
-        this.namespace = this.getText('.header > .sub-title > a')!;
+        this.package = this.getText('.header > .sub-title > a')!;
 
         // Java Type & Modifiers
         const split = this.getText('.type-signature > .modifiers')!.split(' ');
@@ -257,12 +257,12 @@ export class JavaClass extends JavaElement {
         let path = '';
         let text = '';
         if (format === 'yml') {
-            path = `dist/yml/${this.namespace.replace(/\./g, '/')}/`;
+            path = `dist/yml/${this.package.replace(/\./g, '/')}/`;
             text =
-                `# ${this.namespace}.${this.name}\n` +
+                `# ${this.package}.${this.name}\n` +
                 YAML.stringify(this.toJSONObject());
         } else {
-            path = `dist/json/${this.namespace.replace(/\./g, '/')}/`;
+            path = `dist/json/${this.package.replace(/\./g, '/')}/`;
             text = JSON.stringify(this.toJSONObject());
         }
 

--- a/src/JavaClass.ts
+++ b/src/JavaClass.ts
@@ -181,8 +181,10 @@ export class JavaClass extends JavaElement {
     toJSONObject(): any {
         const obj: {
             fields: { [name: string]: any } | undefined;
+            staticFields: { [name: string]: any } | undefined;
             constructors: any[] | undefined;
             methods: any[] | undefined;
+            staticMethods: any[] | undefined;
             deprecated: boolean | undefined;
             modifiers: string[] | undefined;
             javaType: string;
@@ -190,8 +192,10 @@ export class JavaClass extends JavaElement {
             notes: string | undefined;
         } = {
             fields: undefined,
+            staticFields: undefined,
             constructors: undefined,
             methods: undefined,
+            staticMethods: undefined,
             modifiers: this.modifiers.length !== 0 ? this.modifiers : undefined,
             deprecated: this.deprecated ? true : undefined,
             javaType: this.javaType,
@@ -202,22 +206,43 @@ export class JavaClass extends JavaElement {
         const fieldKeys = Object.keys(this.fields);
         if (fieldKeys.length !== 0) {
             obj.fields = {};
+            obj.staticFields = {};
             fieldKeys.sort((a, b) => a.localeCompare(b));
             for (const key of fieldKeys) {
-                obj.fields[key] = this.fields[key].toJSONObject();
+                if (this.fields[key].modifiers.includes("static")) {
+                    obj.staticFields[key] = this.fields[key].toJSONObject();
+                } else {
+                    obj.fields[key] = this.fields[key].toJSONObject();
+                }
             }
-            
+
+            if (obj.fields.length < 1) {
+                obj.fields = undefined
+            } else if (obj.staticFields.length < 1) {
+                obj.staticFields = undefined
+            }
         }
 
         const methodKeys = Object.keys(this.methods);
         if (methodKeys.length !== 0) {
             obj.methods = [];
+            obj.staticMethods = [];
             methodKeys.sort((a, b) => a.localeCompare(b));
             for (const key of methodKeys) {
                 const cluster = this.methods[key];
                 for (const method of cluster) {
-                    obj.methods.push(method.toJSONObject());
+                    if (method.modifiers.includes("static")) {
+                        obj.staticMethods.push(method.toJSONObject());
+                    } else {
+                        obj.methods.push(method.toJSONObject());
+                    }
                 }
+            }
+
+            if (obj.methods.length < 1) {
+                obj.methods = undefined
+            } else if (obj.staticMethods.length < 1) {
+                obj.staticMethods = undefined
             }
         }
 

--- a/src/JavaConstructor.ts
+++ b/src/JavaConstructor.ts
@@ -38,7 +38,7 @@ export class JavaConstructor extends JavaElement {
         }
 
         const notes =
-            this.element.querySelector('.block')?.firstChild.innerText;
+            this.element.querySelector('.block')?.innerText;
         if (notes != undefined) {
             this.notes = removeHtmlEncoding(notes.trim());
         }

--- a/src/JavaConstructor.ts
+++ b/src/JavaConstructor.ts
@@ -3,7 +3,7 @@
 import { HTMLElement } from 'node-html-parser';
 import { JavaElement } from './JavaElement';
 import { JavaParameter } from './JavaParameter';
-import { removeHtmlEncoding, splitParameters } from './Utils';
+import { removeHtmlEncoding, splitParameters, expandTypeNames } from './Utils';
 
 export class JavaConstructor extends JavaElement {
     readonly modifiers: string[] = [];
@@ -23,7 +23,7 @@ export class JavaConstructor extends JavaElement {
         )?.parentNode;
 
         if (eParameters != null) {
-            const sParameters = splitParameters(eParameters.textContent);
+            const sParameters = splitParameters(expandTypeNames(eParameters));
             for (const sParameter of sParameters) {
                 // const eNotes = this.getElement('.detail > .notes > dd > code');
                 // if (eNotes != undefined) {

--- a/src/JavaField.ts
+++ b/src/JavaField.ts
@@ -3,7 +3,7 @@
 import { HTMLElement } from 'node-html-parser';
 import { JavaElement } from './JavaElement';
 import { JavaType } from './JavaType';
-import { removeHtmlEncoding } from './Utils';
+import { removeHtmlEncoding, expandTypeNames } from './Utils';
 
 export class JavaField extends JavaElement {
     readonly name: string;
@@ -27,7 +27,7 @@ export class JavaField extends JavaElement {
         const eReturnType = this.getElement('.member-signature > .return-type');
         if (eReturnType == undefined) throw new Error("Return Type not defined.");
 
-        let basic = eReturnType.text;
+        let basic = expandTypeNames(eReturnType.parentNode);
         let full: string | undefined = undefined;
         if(basic.indexOf('<') !== -1) {
             full = basic;

--- a/src/JavaMethod.ts
+++ b/src/JavaMethod.ts
@@ -4,14 +4,14 @@ import { HTMLElement } from 'node-html-parser';
 import { JavaElement } from './JavaElement';
 import { JavaParameter } from './JavaParameter';
 import { removeHtmlEncoding, splitParameters } from './Utils';
-import { JavaReturns } from './JavaReturns';
+import { JavaReturn } from './JavaReturn';
 import { JavaType } from './JavaType';
 
 export class JavaMethod extends JavaElement {
     readonly name: string;
     readonly modifiers: string[] = [];
     readonly parameters: JavaParameter[] = [];
-    readonly returns: JavaReturns;
+    readonly return: JavaReturn;
 
     readonly notes: string | undefined;
 
@@ -101,7 +101,7 @@ export class JavaMethod extends JavaElement {
             }
         }
 
-        this.returns = new JavaReturns(
+        this.return = new JavaReturn(
             new JavaType(returnType, returnTypeFull),
             returnNotes,
         );
@@ -119,7 +119,7 @@ export class JavaMethod extends JavaElement {
             parameters: this.parameters.length
                 ? this.parameters.map((a) => a.toJSONObject())
                 : undefined,
-            return: this.returns.toJSONObject(),
+            return: this.return.toJSONObject(),
             notes: this.notes,
         };
     }

--- a/src/JavaMethod.ts
+++ b/src/JavaMethod.ts
@@ -119,7 +119,7 @@ export class JavaMethod extends JavaElement {
             parameters: this.parameters.length
                 ? this.parameters.map((a) => a.toJSONObject())
                 : undefined,
-            returns: this.returns.toJSONObject(),
+            return: this.returns.toJSONObject(),
             notes: this.notes,
         };
     }

--- a/src/JavaMethod.ts
+++ b/src/JavaMethod.ts
@@ -54,7 +54,7 @@ export class JavaMethod extends JavaElement {
             }
         }
 
-        const notes = this.element.querySelector('.block')?.firstChild.text;
+        const notes = this.element.querySelector('.block')?.innerText;
         if (notes != undefined) {
             this.notes = removeHtmlEncoding(notes.trim());
         }

--- a/src/JavaMethod.ts
+++ b/src/JavaMethod.ts
@@ -3,7 +3,7 @@
 import { HTMLElement } from 'node-html-parser';
 import { JavaElement } from './JavaElement';
 import { JavaParameter } from './JavaParameter';
-import { removeHtmlEncoding, splitParameters, expandTypeNames } from './Utils';
+import { removeHtmlEncoding, splitParameters, expandTypeNames, basicTypeFromFull } from './Utils';
 import { JavaReturn } from './JavaReturn';
 import { JavaType } from './JavaType';
 
@@ -28,11 +28,8 @@ export class JavaMethod extends JavaElement {
         const eReturnType = this.getElement('.member-signature > .return-type');
         if (eReturnType == undefined)
             throw new Error('ReturnType not defined.');
-        let returnType = expandTypeNames(eReturnType.parentNode);
-        const returnTypeFull = returnType;
-        if (returnType.indexOf('<') !== -1) {
-            returnType = returnType.split('<')[0];
-        }
+        const returnTypeFull = expandTypeNames(eReturnType.parentNode);
+        const returnType = basicTypeFromFull(returnTypeFull);
         let returnNotes: string | undefined = undefined;
 
         const eParameters = this.getElement(

--- a/src/JavaMethod.ts
+++ b/src/JavaMethod.ts
@@ -3,7 +3,7 @@
 import { HTMLElement } from 'node-html-parser';
 import { JavaElement } from './JavaElement';
 import { JavaParameter } from './JavaParameter';
-import { removeHtmlEncoding, splitParameters } from './Utils';
+import { removeHtmlEncoding, splitParameters, expandTypeNames } from './Utils';
 import { JavaReturn } from './JavaReturn';
 import { JavaType } from './JavaType';
 
@@ -28,7 +28,7 @@ export class JavaMethod extends JavaElement {
         const eReturnType = this.getElement('.member-signature > .return-type');
         if (eReturnType == undefined)
             throw new Error('ReturnType not defined.');
-        let returnType = eReturnType.text;
+        let returnType = expandTypeNames(eReturnType.parentNode);
         const returnTypeFull = returnType;
         if (returnType.indexOf('<') !== -1) {
             returnType = returnType.split('<')[0];
@@ -40,7 +40,7 @@ export class JavaMethod extends JavaElement {
         )?.parentNode;
 
         if (eParameters != null) {
-            const sParameters = splitParameters(eParameters.textContent);
+            const sParameters = splitParameters(expandTypeNames(eParameters));
             for (const sParameter of sParameters) {
                 // const eNotes = this.getElement('.detail > .notes > dd > code');
                 // if (eNotes != undefined) {

--- a/src/JavaNamespace.ts
+++ b/src/JavaNamespace.ts
@@ -15,16 +15,24 @@ export class JavaNamespace {
     save(format: 'yml' | 'json') {
         let path = '';
         let text = '';
+
+        const packages: { [name: string]: any } = {};
+        packages[this.name] = this.toJSONObject();
+        const file = {
+            version: "1.1",
+            languages: {
+                java: {
+                    packages
+                }
+            }
+        }
+
         if (format === 'yml') {
             path = `dist/yml/`;
-            const namespaces: { [name: string]: any } = {};
-            namespaces[this.name] = this.toJSONObject();
-            text = YAML.stringify({namespaces}, null, 2);
+            text = YAML.stringify(file, null, 2);
         } else {
             path = `dist/json/`;
-            const namespaces: { [name: string]: any } = {};
-            namespaces[this.name] = this.toJSONObject();
-            text = JSON.stringify({namespaces}, null, 2);
+            text = JSON.stringify(file, null, 2);
         }
 
         let append = './';

--- a/src/JavaPackage.ts
+++ b/src/JavaPackage.ts
@@ -4,7 +4,7 @@ import * as YAML from 'yaml';
 import * as fs from 'fs';
 import { JavaClass } from './JavaClass';
 
-export class JavaNamespace {
+export class JavaPackage {
     readonly name: string;
     readonly classes: { [name: string]: JavaClass } = {};
 

--- a/src/JavaReturn.ts
+++ b/src/JavaReturn.ts
@@ -2,7 +2,7 @@
 
 import { JavaType } from './JavaType';
 
-export class JavaReturns {
+export class JavaReturn {
     readonly type: JavaType;
     notes: string | undefined;
 

--- a/src/JavaType.ts
+++ b/src/JavaType.ts
@@ -12,7 +12,7 @@ export class JavaType {
     toJSONObject(): any {
         return {
             basic: this.basic,
-            full: this.full && this.full !== this.basic ? this.full : undefined,
+            full: this.full ? this.full : undefined,
         };
     }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -67,6 +67,21 @@ export const expandTypeNames = (
     return fullText
 }
 
+export const basicTypeFromFull = (
+    full: string
+): string => {
+    const parametersStart = full.indexOf("<");
+    if (parametersStart != -1) {
+        full = full.substring(0, parametersStart);
+    }
+
+    full = full
+        .substring(full.lastIndexOf(".") + 1)
+        .replaceAll("$", ".");
+
+    return full
+}
+
 export const splitParameters = (
     paramString: string,
 ): Array<{ name: string; type: string; typeFull: string }> => {
@@ -90,15 +105,10 @@ export const splitParameters = (
         }
 
         item.name = name;
-        item.type = item.type
-            .substring(0, item.type.length - name.length)
-            .trim()
-        item.type = item.type
-            .substring(item.type.lastIndexOf(".") + 1)
-            .replace("$", ".");
         item.typeFull = item.typeFull
             .substring(0, item.typeFull.length - name.length)
             .trim();
+        item.type = basicTypeFromFull(item.typeFull);
     }
 
     let genericIndent = 0;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -54,7 +54,7 @@ export const expandTypeNames = (
             if (title === undefined) {
                 throw new Error("Link in parameters has no title");
             }
-            if (title.startsWith("interface in ") || title.startsWith("class in ") || title.startsWith("class or interface in ")) {
+            if (title.includes("interface in ") || title.includes("class in ")) {
                 const packageName = title.substring(title.lastIndexOf(" ") + 1);
                 fullText = fullText + packageName + ".";
             }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -58,8 +58,10 @@ export const expandTypeNames = (
                 const packageName = title.substring(title.lastIndexOf(" ") + 1);
                 fullText = fullText + packageName + ".";
             }
+            fullText += child.textContent.replaceAll(".", "$");
+        } else {
+            fullText += child.textContent;
         }
-        fullText += child.textContent.replace(".", "$");
     }
 
     return fullText

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,5 +1,7 @@
 /* eslint-disable prettier/prettier */
 
+import { HTMLElement, Node, NodeType } from "node-html-parser";
+
 const RESERVED_FUNCTION_NAMES = ['toString', 'valueOf'];
 const RESERVED_WORDS = [
     'and',
@@ -40,6 +42,29 @@ export const removeHtmlEncoding = (s: string): string => {
         .replaceAll('&nbsp;', ' ');
 };
 
+export const expandTypeNames = (
+    node: Node
+): string => {
+    var fullText = ""
+
+    for (const child of node.childNodes) {
+        const htmlNode = <HTMLElement> child;
+        if (htmlNode.tagName === "A") {
+            const title = htmlNode.getAttribute("title");
+            if (title === undefined) {
+                throw new Error("Link in parameters has no title");
+            }
+            if (title.startsWith("interface in ") || title.startsWith("class in ") || title.startsWith("class or interface in ")) {
+                const packageName = title.substring(title.lastIndexOf(" ") + 1);
+                fullText = fullText + packageName + ".";
+            }
+        }
+        fullText += child.textContent.replace(".", "$");
+    }
+
+    return fullText
+}
+
 export const splitParameters = (
     paramString: string,
 ): Array<{ name: string; type: string; typeFull: string }> => {
@@ -65,7 +90,10 @@ export const splitParameters = (
         item.name = name;
         item.type = item.type
             .substring(0, item.type.length - name.length)
-            .trim();
+            .trim()
+        item.type = item.type
+            .substring(item.type.lastIndexOf(".") + 1)
+            .replace("$", ".");
         item.typeFull = item.typeFull
             .substring(0, item.typeFull.length - name.length)
             .trim();


### PR DESCRIPTION
Updates the output format to adhere to the current version of Rosetta.
This also renames the classes `JavaNamespace` and `JavaReturns` to `JavaPackage` and `JavaReturn` for consistency with their new names in Rosetta.